### PR TITLE
Fix P3-SAM: hardcoded sampling params, missing prompt_bs, broken cache paths

### DIFF
--- a/P3-SAM/demo/auto_mask.py
+++ b/P3-SAM/demo/auto_mask.py
@@ -776,8 +776,6 @@ def mesh_sam(
     if show_info:
         print(f"点数：{mesh.vertices.shape[0]} 面片数：{mesh.faces.shape[0]}")
 
-    point_num = 100000
-    prompt_num = 400
     with Timer("获取邻接面片"):
         face_adjacency = mesh.face_adjacency
     with Timer("处理邻接面片"):
@@ -1338,30 +1336,32 @@ if __name__ == '__main__':
             os.makedirs(_output_path, exist_ok=True)
             mesh = trimesh.load(_mesh_path, force='mesh')
             set_seed(args.seed)
-            aabb, face_ids, mesh = auto_mask.predict_aabb(mesh, 
-                                                        save_path=_output_path, 
-                                                        point_num=args.point_num, 
-                                                        prompt_num=args.prompt_num, 
-                                                        threshold=args.threshold, 
-                                                        post_process=args.post_process, 
-                                                        save_mid_res=args.save_mid_res, 
+            aabb, face_ids, mesh = auto_mask.predict_aabb(mesh,
+                                                        save_path=_output_path,
+                                                        point_num=args.point_num,
+                                                        prompt_num=args.prompt_num,
+                                                        threshold=args.threshold,
+                                                        post_process=args.post_process,
+                                                        save_mid_res=args.save_mid_res,
                                                         show_info=args.show_info,
                                                         seed=args.seed,
                                                         is_parallel=args.parallel,
+                                                        prompt_bs=args.prompt_bs,
                                                         clean_mesh_flag=args.clean_mesh,)
     else:     
         mesh = trimesh.load(mesh_path, force='mesh')
         set_seed(args.seed)
-        aabb, face_ids, mesh = auto_mask.predict_aabb(mesh, 
-                                                    save_path=output_path, 
-                                                    point_num=args.point_num, 
-                                                    prompt_num=args.prompt_num, 
-                                                    threshold=args.threshold, 
-                                                    post_process=args.post_process, 
-                                                    save_mid_res=args.save_mid_res, 
+        aabb, face_ids, mesh = auto_mask.predict_aabb(mesh,
+                                                    save_path=output_path,
+                                                    point_num=args.point_num,
+                                                    prompt_num=args.prompt_num,
+                                                    threshold=args.threshold,
+                                                    post_process=args.post_process,
+                                                    save_mid_res=args.save_mid_res,
                                                     show_info=args.show_info,
                                                     seed=args.seed,
                                                     is_parallel=args.parallel,
+                                                    prompt_bs=args.prompt_bs,
                                                     clean_mesh_flag=args.clean_mesh,)
 
     ###############################################

--- a/P3-SAM/model.py
+++ b/P3-SAM/model.py
@@ -15,7 +15,9 @@ The model is composed of three parts:
 '''
 def build_P3SAM(self): #build p3sam
     ######################## Sonata ########################
-    self.sonata = sonata.load("sonata", repo_id="facebook/sonata", download_root='/root/sonata')
+    import os as _os
+    _sonata_cache = _os.path.join(_os.path.expanduser("~"), ".cache", "sonata")
+    self.sonata = sonata.load("sonata", repo_id="facebook/sonata", download_root=_sonata_cache)
     self.mlp = nn.Sequential(
             nn.Linear(1232, 512),
             nn.GELU(),
@@ -122,7 +124,7 @@ def load_state_dict(self,
         # download from huggingface
         print(f'trying to download model from huggingface...')
         from huggingface_hub import hf_hub_download
-        ckpt_path = hf_hub_download(repo_id="tencent/Hunyuan3D-Part", filename="p3sam/p3sam.safetensors", local_dir=os.path.join(os.path.expanduser('~'), '/.cache/p3sam/weights'))
+        ckpt_path = hf_hub_download(repo_id="tencent/Hunyuan3D-Part", filename="p3sam/p3sam.safetensors", local_dir=os.path.join(os.path.expanduser('~'), '.cache', 'p3sam', 'weights'))
         print(f'download model from huggingface to: {ckpt_path}')
         from safetensors.torch import load_file
         state_dict = load_file(ckpt_path)


### PR DESCRIPTION
## Summary

Three small bug fixes in P3-SAM that were preventing CLI flags from taking effect and causing permission errors / OOMs on non-root and non-H100 setups.

## Fixes

**1. `P3-SAM/demo/auto_mask.py` — hardcoded overrides in `mesh_sam()`**
The function header accepts `point_num` / `prompt_num` arguments, but two lines immediately after the header silently overwrote them with `100000` / `400`, making the arguments dead. Removed.

**2. `P3-SAM/demo/auto_mask.py` — `prompt_bs` not plumbed through `__main__`**
Both `predict_aabb(...)` call sites in `if __name__ == '__main__'` (the directory branch and the single-file branch) were missing `prompt_bs=args.prompt_bs`. The CLI `--prompt_bs` flag was therefore silently ignored and always defaulted to 32, which produces a ~13 GB intermediate tensor and OOMs on anything below an H100. Added the kwarg in both places.

**3. `P3-SAM/model.py` — hardcoded `/root/...` paths**
- Sonata cache dir was hardcoded to `/root/sonata` (PermissionError as a non-root user). Switched to `~/.cache/sonata`.
- HF download `local_dir` used `os.path.join(os.path.expanduser('~'), '/.cache/p3sam/weights')` — the leading `/` makes `os.path.join` discard the home prefix, so weights landed in `/.cache/...` instead of `$HOME/.cache/...`. Removed the leading slash.

## Test plan

- [x] Verified `--prompt_bs 4` is now respected end-to-end (no more 13 GB tensor allocation; runs on a 24 GB GPU)
- [x] Verified `--point_num` / `--prompt_num` from CLI now reach `mesh_sam`
- [x] Verified weights download to `~/.cache/p3sam/weights` and sonata to `~/.cache/sonata` as a non-root user